### PR TITLE
chore: add issue templates and .gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Report a reproducible problem or regression
+title: "bug: <short description>"
+labels: [bug]
+assignees: []
+---
+
+## Description
+A clear and concise description of the problem.
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened (include screenshots if useful).
+
+## Logs / Stacktrace
+```
+(paste relevant log excerpt)
+```
+
+## Environment
+- Service / Module: 
+- Runtime (e.g. Node.js 20, Python 3.11, JDK 21): 
+- OS / Arch: 
+- Branch / Commit: 
+- Deployment (local | dev | staging | prod): 
+
+## Possible Cause (optional)
+If you have a hypothesis, add it here.
+
+## Additional Context
+Add any other context, links, or references.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/qoweh/BE/discussions
+    about: Please use GitHub Discussions for open-ended questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: "feat: <short description>"
+labels: [enhancement]
+assignees: []
+---
+
+## Summary
+Briefly describe the feature.
+
+## Motivation / Problem
+What problem does this solve? Why is it important?
+
+## Proposed Solution
+Describe the solution you'd like (APIs, endpoints, data model changes, etc.).
+
+## Alternatives Considered
+List any alternative solutions or workarounds.
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Acceptance Criteria
+- [ ] 
+- [ ] 
+
+## Impacted Areas
+Services, modules, or components affected.
+
+## Dependencies / Blockers
+List external or internal dependencies.
+
+## Additional Context
+Links, diagrams, references.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,30 @@
+---
+name: Development task
+about: Track a granular implementation, refactor, or chore
+title: "chore: <short description>"
+labels: [task]
+assignees: []
+---
+
+## Goal
+What needs to be accomplished.
+
+## Description
+Detail of the work to do.
+
+## Subtasks
+- [ ] 
+- [ ] 
+
+## Definition of Done
+- [ ] Code implemented
+- [ ] Tests added/updated
+- [ ] CI green
+- [ ] Documentation updated (if needed)
+- [ ] Reviewed & approved
+
+## Risks / Mitigations
+Potential risks and how to mitigate them.
+
+## Additional Context
+Anything else helpful.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Node / TypeScript
+node_modules/
+dist/
+build/
+coverage/
+.nyc_output/
+*.tsbuildinfo
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.env
+.env.*
+
+# Java / JVM
+*.class
+*.jar
+*.war
+*.ear
+.target/
+
+# Logs & diagnostics
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# IDE / Editor
+.vscode/
+.idea/
+*.swp
+.DS_Store
+
+# Docker
+*.tar
+**/docker-data/
+
+# Cache / Misc
+.cache/
+.tmp/
+.tmp/**
+coverage-final.json
+
+# OS
+Thumbs.db
+
+# Runtime data
+pids/
+*.pid
+*.seed
+
+# Local only
+local-
+secrets.local.*
+
+# Test artifacts
+junit-report.xml


### PR DESCRIPTION
### Summary
Adds standardized GitHub issue templates (bug report, feature request, task) and a comprehensive backend-oriented `.gitignore`.

### Details
- Introduces `.github/ISSUE_TEMPLATE` with:
  - `bug_report.md`
  - `feature_request.md`
  - `task.md`
  - `config.yml` disabling blank issues and directing questions to Discussions.
- Adds a multi-language `.gitignore` tuned for backend development (Node, Python, JVM, logs, IDE files, Docker artifacts, caches, test artifacts) and explicitly ignores `.vscode/` as requested.

### Rationale
Provides structured issue intake to improve triage and consistency. `.gitignore` prevents committing local environment, build outputs, and editor artifacts.

### Checklist
- [x] Issue templates added
- [x] `.gitignore` added with `.vscode/` ignored

### Next Steps (optional)
- Consider adding PR template
- Add CI workflow (lint + test)
- Add CODEOWNERS for review routing
